### PR TITLE
Support organization switch grant for federated users

### DIFF
--- a/components/org.wso2.carbon.identity.oauth2.grant.organizationswitch/pom.xml
+++ b/components/org.wso2.carbon.identity.oauth2.grant.organizationswitch/pom.xml
@@ -95,7 +95,10 @@
                             org.wso2.carbon.identity.organization.management.service.exception; version="${org.wso2.identity.organization.mgt.core.imp.pkg.version.range}",
                             org.wso2.carbon.identity.organization.management.service.util; version="${org.wso2.identity.organization.mgt.core.imp.pkg.version.range}",
                             org.wso2.carbon.user.api;version="${carbon.user.api.imp.pkg.version.range}",
+                            org.wso2.carbon.user.core;version="${carbon.kernel.package.import.version.range}",
                             org.wso2.carbon.user.core.service;version="${carbon.kernel.package.import.version.range}",
+                            org.wso2.carbon.user.core.tenant;version="${carbon.kernel.package.import.version.range}",
+                            org.wso2.carbon.user.core.common;version="${carbon.kernel.package.import.version.range}",
                         </Import-Package>
                     </instructions>
                 </configuration>

--- a/components/org.wso2.carbon.identity.oauth2.grant.organizationswitch/src/main/java/org/wso2/carbon/identity/oauth2/grant/organizationswitch/OrganizationSwitchGrant.java
+++ b/components/org.wso2.carbon.identity.oauth2.grant.organizationswitch/src/main/java/org/wso2/carbon/identity/oauth2/grant/organizationswitch/OrganizationSwitchGrant.java
@@ -23,8 +23,6 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.identity.application.authentication.framework.exception.UserIdNotFoundException;
 import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticatedUser;
-import org.wso2.carbon.identity.application.common.model.FederatedAuthenticatorConfig;
-import org.wso2.carbon.identity.application.common.model.IdentityProvider;
 import org.wso2.carbon.identity.application.common.model.User;
 import org.wso2.carbon.identity.oauth2.IdentityOAuth2Exception;
 import org.wso2.carbon.identity.oauth2.OAuth2TokenValidationService;
@@ -32,6 +30,8 @@ import org.wso2.carbon.identity.oauth2.dto.OAuth2ClientApplicationDTO;
 import org.wso2.carbon.identity.oauth2.dto.OAuth2TokenValidationRequestDTO;
 import org.wso2.carbon.identity.oauth2.dto.OAuth2TokenValidationResponseDTO;
 import org.wso2.carbon.identity.oauth2.grant.organizationswitch.exception.OrganizationSwitchGrantException;
+import org.wso2.carbon.identity.oauth2.grant.organizationswitch.exception.OrganizationSwitchGrantServerException;
+import org.wso2.carbon.identity.oauth2.grant.organizationswitch.internal.OrganizationSwitchGrantDataHolder;
 import org.wso2.carbon.identity.oauth2.grant.organizationswitch.util.OrganizationSwitchGrantConstants;
 import org.wso2.carbon.identity.oauth2.grant.organizationswitch.util.OrganizationSwitchGrantUtil;
 import org.wso2.carbon.identity.oauth2.model.AccessTokenDO;
@@ -44,14 +44,14 @@ import org.wso2.carbon.identity.organization.management.service.OrganizationMana
 import org.wso2.carbon.identity.organization.management.service.exception.OrganizationManagementException;
 
 import java.util.Arrays;
+import java.util.Optional;
 
 import static java.util.Objects.nonNull;
-import static java.util.Optional.ofNullable;
-import static org.apache.commons.lang.StringUtils.equalsIgnoreCase;
+
 import static org.apache.commons.lang.StringUtils.isBlank;
-import static org.wso2.carbon.identity.oauth2.grant.organizationswitch.util.OrganizationSwitchGrantConstants.ORGANIZATION_AUTHENTICATOR;
 import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.ErrorMessages.ERROR_CODE_ERROR_RESOLVING_TENANT_DOMAIN_FROM_ORGANIZATION_DOMAIN;
 import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.ErrorMessages.ERROR_CODE_ERROR_RETRIEVING_AUTHENTICATED_USER;
+import static org.wso2.carbon.user.core.UserCoreConstants.TENANT_DOMAIN_COMBINER;
 
 /**
  * Implements the AuthorizationGrantHandler for the OrganizationSwitch grant type.
@@ -73,44 +73,43 @@ public class OrganizationSwitchGrant extends AbstractAuthorizationGrantHandler {
         OAuth2TokenValidationResponseDTO validationResponseDTO = validateToken(token);
 
         if (!validationResponseDTO.isValid()) {
-            if (LOG.isDebugEnabled()) {
-                LOG.debug("Access token validation failed.");
-            }
+            LOG.debug("Access token validation failed.");
 
             throw new IdentityOAuth2Exception("Invalid token received.");
         }
 
-        if (LOG.isDebugEnabled()) {
-            LOG.debug("Access token validation success.");
-        }
+        LOG.debug("Access token validation success.");
 
         AccessTokenDO tokenDO = OAuth2Util.findAccessToken(token, false);
         AuthenticatedUser authorizedUser = nonNull(tokenDO) ? tokenDO.getAuthzUser() :
                 AuthenticatedUser.createLocalAuthenticatedUserFromSubjectIdentifier(
                         validationResponseDTO.getAuthorizedUser());
 
+        AuthenticatedUser authenticatedUser = new AuthenticatedUser();
+        authenticatedUser.setTenantDomain(getTenantDomainFromOrganizationId(organizationId));
+
         String userId = null;
         if (authorizedUser.isFederatedUser()) {
-            IdentityProvider idp = OAuth2Util.getIdentityProvider(authorizedUser.getFederatedIdPName(),
-                    authorizedUser.getTenantDomain());
-            if (equalsIgnoreCase(ORGANIZATION_AUTHENTICATOR,
-                    ofNullable(idp.getDefaultAuthenticatorConfig()).map(FederatedAuthenticatorConfig::getName)
-                            .orElse(null))) {
-                // If the user bound to the token is a federated user and the user is authenticated via
-                // OrganizationLogin Authenticator accessing the organization_switch grant, the user ID is populated
-                // as the username.
-                userId = authorizedUser.getUserName();
+            // username contains the userId for federated users.
+            userId = authorizedUser.getUserName();
+            Optional<org.wso2.carbon.user.core.common.User> optionalUser =
+                    getFederatedUserFromResidentOrganization(userId, organizationId);
+            if (optionalUser.isPresent()) {
+                org.wso2.carbon.user.core.common.User federatedLocalUser = optionalUser.get();
+                authenticatedUser.setUserName(federatedLocalUser.getUsername());
+                authenticatedUser.setUserStoreDomain(federatedLocalUser.getUserStoreDomain());
+                authenticatedUser.setAuthenticatedSubjectIdentifier(federatedLocalUser.getUsername() +
+                        TENANT_DOMAIN_COMBINER + authenticatedUser.getTenantDomain());
             }
+        } else {
+            authenticatedUser.setUserName(authorizedUser.getUserName());
+            authenticatedUser.setUserStoreDomain(authorizedUser.getUserStoreDomain());
         }
 
         if (isBlank(userId)) {
             userId = getUserIdFromAuthorizedUser(authorizedUser);
         }
 
-        AuthenticatedUser authenticatedUser = new AuthenticatedUser();
-        authenticatedUser.setUserName(authorizedUser.getUserName());
-        authenticatedUser.setUserStoreDomain(authorizedUser.getUserStoreDomain());
-        authenticatedUser.setTenantDomain(getTenantDomainFromOrganizationId(organizationId));
         authenticatedUser.setUserId(userId);
 
         tokReqMsgCtx.setAuthorizedUser(authenticatedUser);
@@ -190,4 +189,15 @@ public class OrganizationSwitchGrant extends AbstractAuthorizationGrantHandler {
         }
     }
 
+    private Optional<org.wso2.carbon.user.core.common.User> getFederatedUserFromResidentOrganization(String userId,
+                                                                                                     String organizationId)
+            throws OrganizationSwitchGrantServerException {
+
+        try {
+            return OrganizationSwitchGrantDataHolder.getInstance().getOrganizationUserResidentResolverService()
+                    .resolveUserFromResidentOrganization(null, userId, organizationId);
+        } catch (OrganizationManagementException e) {
+            throw OrganizationSwitchGrantUtil.handleServerException(ERROR_CODE_ERROR_RETRIEVING_AUTHENTICATED_USER, e);
+        }
+    }
 }

--- a/components/org.wso2.carbon.identity.oauth2.grant.organizationswitch/src/main/java/org/wso2/carbon/identity/oauth2/grant/organizationswitch/internal/OrganizationSwitchGrantDataHolder.java
+++ b/components/org.wso2.carbon.identity.oauth2.grant.organizationswitch/src/main/java/org/wso2/carbon/identity/oauth2/grant/organizationswitch/internal/OrganizationSwitchGrantDataHolder.java
@@ -18,6 +18,7 @@
 
 package org.wso2.carbon.identity.oauth2.grant.organizationswitch.internal;
 
+
 import org.wso2.carbon.identity.organization.management.service.OrganizationUserResidentResolverService;
 
 /**

--- a/components/org.wso2.carbon.identity.oauth2.grant.organizationswitch/src/main/java/org/wso2/carbon/identity/oauth2/grant/organizationswitch/internal/OrganizationSwitchGrantDataHolder.java
+++ b/components/org.wso2.carbon.identity.oauth2.grant.organizationswitch/src/main/java/org/wso2/carbon/identity/oauth2/grant/organizationswitch/internal/OrganizationSwitchGrantDataHolder.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2022, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.oauth2.grant.organizationswitch.internal;
+
+import org.wso2.carbon.identity.organization.management.service.OrganizationUserResidentResolverService;
+
+/**
+ * Organization switch grant data holder.
+ */
+public class OrganizationSwitchGrantDataHolder {
+
+    private static OrganizationSwitchGrantDataHolder instance = new OrganizationSwitchGrantDataHolder();
+
+    private OrganizationUserResidentResolverService organizationUserResidentResolverService;
+
+    public static OrganizationSwitchGrantDataHolder getInstance() {
+
+        return instance;
+    }
+
+    public OrganizationUserResidentResolverService getOrganizationUserResidentResolverService() {
+
+        return organizationUserResidentResolverService;
+    }
+
+    public void setOrganizationUserResidentResolverService
+            (OrganizationUserResidentResolverService organizationUserResidentResolverService) {
+
+        this.organizationUserResidentResolverService = organizationUserResidentResolverService;
+    }
+}

--- a/components/org.wso2.carbon.identity.oauth2.grant.organizationswitch/src/main/java/org/wso2/carbon/identity/oauth2/grant/organizationswitch/internal/OrganizationSwitchGrantServiceComponent.java
+++ b/components/org.wso2.carbon.identity.oauth2.grant.organizationswitch/src/main/java/org/wso2/carbon/identity/oauth2/grant/organizationswitch/internal/OrganizationSwitchGrantServiceComponent.java
@@ -49,7 +49,8 @@ public class OrganizationSwitchGrantServiceComponent {
                 .setOrganizationUserResidentResolverService(organizationUserResidentResolverService);
     }
 
-    protected void unsetOrganizationUserResidentResolverService(OrganizationUserResidentResolverService organizationUserResidentResolverService) {
+    protected void unsetOrganizationUserResidentResolverService(
+            OrganizationUserResidentResolverService organizationUserResidentResolverService) {
 
         LOG.debug("Organization user resident resolver service is unset.");
         OrganizationSwitchGrantDataHolder.getInstance().setOrganizationUserResidentResolverService(null);

--- a/components/org.wso2.carbon.identity.oauth2.grant.organizationswitch/src/main/java/org/wso2/carbon/identity/oauth2/grant/organizationswitch/internal/OrganizationSwitchGrantServiceComponent.java
+++ b/components/org.wso2.carbon.identity.oauth2.grant.organizationswitch/src/main/java/org/wso2/carbon/identity/oauth2/grant/organizationswitch/internal/OrganizationSwitchGrantServiceComponent.java
@@ -18,7 +18,13 @@
 
 package org.wso2.carbon.identity.oauth2.grant.organizationswitch.internal;
 
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferenceCardinality;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.wso2.carbon.identity.organization.management.service.OrganizationUserResidentResolverService;
 
 /**
  * This class contains the service component of the organization switching grant type.
@@ -28,5 +34,24 @@ import org.osgi.service.component.annotations.Component;
         immediate = true
 )
 public class OrganizationSwitchGrantServiceComponent {
-    
+
+    private static final Log LOG = LogFactory.getLog(OrganizationSwitchGrantServiceComponent.class);
+
+    @Reference(name = "identity.organization.management.user.resident.resolver.service.component",
+            service = OrganizationUserResidentResolverService.class,
+            cardinality = ReferenceCardinality.MANDATORY,
+            policy = ReferencePolicy.DYNAMIC,
+            unbind = "unsetOrganizationUserResidentResolverService")
+    protected void setOrganizationUserResidentResolverService(OrganizationUserResidentResolverService organizationUserResidentResolverService) {
+
+        LOG.debug("Organization user resident resolver service is set.");
+        OrganizationSwitchGrantDataHolder.getInstance()
+                .setOrganizationUserResidentResolverService(organizationUserResidentResolverService);
+    }
+
+    protected void unsetOrganizationUserResidentResolverService(OrganizationUserResidentResolverService organizationUserResidentResolverService) {
+
+        LOG.debug("Organization user resident resolver service is unset.");
+        OrganizationSwitchGrantDataHolder.getInstance().setOrganizationUserResidentResolverService(null);
+    }
 }


### PR DESCRIPTION
## Purpose

The organization switch grant handler still support the federated users who are federated from OrganizationLogin authenticator. But the users who are authenticated from other federated authenticators like EnterPriseIDP authenticator also should support to exchange tokens by using this grant handler. 

The following image is an example of a federated user who is federated from EnterpriseIDP authenticator. Usually the federated username includes the federated userId, but in this flow it includes the username. In order to get the userId, the user has to be retrieved if user can be found in the organization hierarchy. (Due to a local user is resolved via a federated authenticator, the user can be resolved easily. )

![Screenshot 2022-10-26 at 15 00 30](https://user-images.githubusercontent.com/35717390/198011390-b30b5b8e-1be3-4206-b47e-49cea090f8b4.png)
