### PR TITLE
Add token binding ref to the Organization Switch Grant token

### DIFF
--- a/components/org.wso2.carbon.identity.oauth2.grant.organizationswitch/pom.xml
+++ b/components/org.wso2.carbon.identity.oauth2.grant.organizationswitch/pom.xml
@@ -89,6 +89,7 @@
                             org.wso2.carbon.identity.oauth2.model; version="${identity.inbound.auth.oauth.version}",
                             org.wso2.carbon.identity.oauth2.token; version="${identity.inbound.auth.oauth.version}",
                             org.wso2.carbon.identity.oauth2.token.handlers.grant; version="${identity.inbound.auth.oauth.version}",
+                            org.wso2.carbon.identity.oauth2.token.bindings; version="${identity.inbound.auth.oauth.version}",
                             org.wso2.carbon.identity.oauth2.util; version="${identity.inbound.auth.oauth.version}",
                             org.wso2.carbon.identity.organization.management.service; version="${org.wso2.identity.organization.mgt.core.imp.pkg.version.range}",
                             org.wso2.carbon.identity.organization.management.service.constant; version="${org.wso2.identity.organization.mgt.core.imp.pkg.version.range}",

--- a/components/org.wso2.carbon.identity.oauth2.grant.organizationswitch/src/main/java/org/wso2/carbon/identity/oauth2/grant/organizationswitch/OrganizationSwitchGrant.java
+++ b/components/org.wso2.carbon.identity.oauth2.grant.organizationswitch/src/main/java/org/wso2/carbon/identity/oauth2/grant/organizationswitch/OrganizationSwitchGrant.java
@@ -150,7 +150,7 @@ public class OrganizationSwitchGrant extends AbstractAuthorizationGrantHandler {
     @Override
     public OAuth2AccessTokenRespDTO issue(OAuthTokenReqMessageContext tokReqMsgCtx) throws IdentityOAuth2Exception {
 
-        String tokenBindingRef = "org_switch_" + tokReqMsgCtx.getProperty("tokenBindingReference");
+        String tokenBindingRef = "os_" + tokReqMsgCtx.getProperty("tokenBindingReference");
         OAuth2AccessTokenRespDTO oAuth2AccessTokenRespDTO = super.issue(tokReqMsgCtx);
         // Update the token binding reference with the new token id.
         updateTokenBindingRef(oAuth2AccessTokenRespDTO.getTokenId(), tokenBindingRef);

--- a/components/org.wso2.carbon.identity.oauth2.grant.organizationswitch/src/main/java/org/wso2/carbon/identity/oauth2/grant/organizationswitch/OrganizationSwitchGrant.java
+++ b/components/org.wso2.carbon.identity.oauth2.grant.organizationswitch/src/main/java/org/wso2/carbon/identity/oauth2/grant/organizationswitch/OrganizationSwitchGrant.java
@@ -21,16 +21,24 @@ package org.wso2.carbon.identity.oauth2.grant.organizationswitch;
 import org.apache.commons.lang.ArrayUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.context.PrivilegedCarbonContext;
 import org.wso2.carbon.identity.application.authentication.framework.exception.UserIdNotFoundException;
 import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticatedUser;
 import org.wso2.carbon.identity.application.common.model.FederatedAuthenticatorConfig;
 import org.wso2.carbon.identity.application.common.model.IdentityProvider;
 import org.wso2.carbon.identity.application.common.model.User;
+import org.wso2.carbon.identity.core.util.IdentityDatabaseUtil;
+import org.wso2.carbon.identity.oauth.common.OAuth2ErrorCodes;
 import org.wso2.carbon.identity.oauth2.IdentityOAuth2Exception;
+import org.wso2.carbon.identity.oauth2.OAuth2Service;
 import org.wso2.carbon.identity.oauth2.OAuth2TokenValidationService;
+import org.wso2.carbon.identity.oauth2.bean.OAuthClientAuthnContext;
+import org.wso2.carbon.identity.oauth2.dto.OAuth2AccessTokenRespDTO;
 import org.wso2.carbon.identity.oauth2.dto.OAuth2ClientApplicationDTO;
 import org.wso2.carbon.identity.oauth2.dto.OAuth2TokenValidationRequestDTO;
 import org.wso2.carbon.identity.oauth2.dto.OAuth2TokenValidationResponseDTO;
+import org.wso2.carbon.identity.oauth2.dto.OAuthRevocationRequestDTO;
+import org.wso2.carbon.identity.oauth2.dto.OAuthRevocationResponseDTO;
 import org.wso2.carbon.identity.oauth2.grant.organizationswitch.exception.OrganizationSwitchGrantException;
 import org.wso2.carbon.identity.oauth2.grant.organizationswitch.exception.OrganizationSwitchGrantServerException;
 import org.wso2.carbon.identity.oauth2.grant.organizationswitch.internal.OrganizationSwitchGrantDataHolder;
@@ -45,6 +53,9 @@ import org.wso2.carbon.identity.organization.management.service.OrganizationMana
 import org.wso2.carbon.identity.organization.management.service.OrganizationManagerImpl;
 import org.wso2.carbon.identity.organization.management.service.exception.OrganizationManagementException;
 
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
 import java.util.Arrays;
 import java.util.Optional;
 
@@ -88,7 +99,6 @@ public class OrganizationSwitchGrant extends AbstractAuthorizationGrantHandler {
         AuthenticatedUser authorizedUser = nonNull(tokenDO) ? tokenDO.getAuthzUser() :
                 AuthenticatedUser.createLocalAuthenticatedUserFromSubjectIdentifier(
                         validationResponseDTO.getAuthorizedUser());
-
         AuthenticatedUser authenticatedUser = new AuthenticatedUser();
         authenticatedUser.setUserName(authorizedUser.getUserName());
         authenticatedUser.setUserStoreDomain(authorizedUser.getUserStoreDomain());
@@ -127,6 +137,7 @@ public class OrganizationSwitchGrant extends AbstractAuthorizationGrantHandler {
 
         String[] allowedScopes = tokReqMsgCtx.getOauth2AccessTokenReqDTO().getScope();
         tokReqMsgCtx.setScope(allowedScopes);
+        tokReqMsgCtx.addProperty("tokenBindingReference", tokenDO.getTokenBinding().getBindingReference());
 
         if (LOG.isDebugEnabled()) {
             LOG.debug("Issuing an access token for user: " + authenticatedUser + " with scopes: " +
@@ -134,6 +145,16 @@ public class OrganizationSwitchGrant extends AbstractAuthorizationGrantHandler {
         }
 
         return true;
+    }
+
+    @Override
+    public OAuth2AccessTokenRespDTO issue(OAuthTokenReqMessageContext tokReqMsgCtx) throws IdentityOAuth2Exception {
+
+        String tokenBindingRef = "org_switch_" + tokReqMsgCtx.getProperty("tokenBindingReference");
+        OAuth2AccessTokenRespDTO oAuth2AccessTokenRespDTO = super.issue(tokReqMsgCtx);
+        // Update the token binding reference with the new token id.
+        updateTokenBindingRef(oAuth2AccessTokenRespDTO.getTokenId(), tokenBindingRef);
+        return oAuth2AccessTokenRespDTO;
     }
 
     private String extractParameter(String param, OAuthTokenReqMessageContext tokReqMsgCtx) {
@@ -212,4 +233,32 @@ public class OrganizationSwitchGrant extends AbstractAuthorizationGrantHandler {
         }
     }
 
+    /**
+     * Update the token binding reference with the new token id.
+     *
+     * @param tokenId Token id.
+     * @param tokenBindingRef Token binding reference.
+     * @throws IdentityOAuth2Exception If an error occurs while updating the token binding reference.
+     */
+    private void updateTokenBindingRef(String tokenId, String tokenBindingRef)
+            throws IdentityOAuth2Exception {
+
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("Updating token binding reference for token id: " + tokenId);
+        }
+        String sql = "UPDATE IDN_OAUTH2_ACCESS_TOKEN SET TOKEN_BINDING_REF=? WHERE TOKEN_ID=?";
+        try (Connection connection = IdentityDatabaseUtil.getDBConnection(true)) {
+            try (PreparedStatement prepStmt = connection.prepareStatement(sql)) {
+                prepStmt.setString(1, tokenBindingRef);
+                prepStmt.setString(2, tokenId);
+                prepStmt.executeUpdate();
+                IdentityDatabaseUtil.commitTransaction(connection);
+            } catch (SQLException e) {
+                IdentityDatabaseUtil.rollbackTransaction(connection);
+                throw new IdentityOAuth2Exception("Error while updating the access token.", e);
+            }
+        } catch (SQLException e) {
+            throw new IdentityOAuth2Exception("Error while updating Access Token with ID: " + tokenId, e);
+        }
+    }
 }

--- a/components/org.wso2.carbon.identity.oauth2.grant.organizationswitch/src/main/java/org/wso2/carbon/identity/oauth2/grant/organizationswitch/util/OrganizationSwitchGrantConstants.java
+++ b/components/org.wso2.carbon.identity.oauth2.grant.organizationswitch/src/main/java/org/wso2/carbon/identity/oauth2/grant/organizationswitch/util/OrganizationSwitchGrantConstants.java
@@ -25,6 +25,8 @@ public class OrganizationSwitchGrantConstants {
 
     public static final String ORGANIZATION_AUTHENTICATOR = "OrganizationAuthenticator";
 
+    public static final String TOKEN_BINDING_REFERENCE = "tokenBindingReference";
+
     /**
      * Constants related to request parameters.
      */


### PR DESCRIPTION
## Purpose

- Get the token binding of the Authorization Code Grant token and add it to the Organization Switch Grant token with a prefix. Then revoke both tokens upon a successful logout request. 

## Related Issue

- https://github.com/wso2-enterprise/wso2-iam-internal/issues/390

*** Note:
Do not merge since we need to do a DB migration before we deploy this.