### PR TITLE
Allow switching to the root organization from a token issued for a child organization

### DIFF
--- a/components/org.wso2.carbon.identity.oauth2.grant.organizationswitch/src/main/java/org/wso2/carbon/identity/oauth2/grant/organizationswitch/OrganizationSwitchGrant.java
+++ b/components/org.wso2.carbon.identity.oauth2.grant.organizationswitch/src/main/java/org/wso2/carbon/identity/oauth2/grant/organizationswitch/OrganizationSwitchGrant.java
@@ -91,13 +91,15 @@ public class OrganizationSwitchGrant extends AbstractAuthorizationGrantHandler {
         checkOrganizationIsAllowedToSwitch(appResideOrgId, accessingOrgId, appId, appName);
 
         AuthenticatedUser authenticatedUser = new AuthenticatedUser(authorizedUser);
-        authenticatedUser.setAccessingOrganization(accessingOrgId);
-        if (StringUtils.isEmpty(authorizedUser.getUserResidentOrganization())) {
-            authenticatedUser.setUserResidentOrganization(appResideOrgId);
-        } else {
-            authenticatedUser.setUserResidentOrganization(authorizedUser.getUserResidentOrganization());
+        // The accessing and resident organization values are not set when switching for root organization.
+        if (!StringUtils.equals(appResideOrgId, accessingOrgId)) {
+            authenticatedUser.setAccessingOrganization(accessingOrgId);
+            if (StringUtils.isEmpty(authorizedUser.getUserResidentOrganization())) {
+                authenticatedUser.setUserResidentOrganization(appResideOrgId);
+            } else {
+                authenticatedUser.setUserResidentOrganization(authorizedUser.getUserResidentOrganization());
+            }
         }
-
         tokReqMsgCtx.setAuthorizedUser(authenticatedUser);
 
         String[] allowedScopes = tokReqMsgCtx.getOauth2AccessTokenReqDTO().getScope();

--- a/components/org.wso2.carbon.identity.oauth2.grant.organizationswitch/src/main/java/org/wso2/carbon/identity/oauth2/grant/organizationswitch/OrganizationSwitchGrant.java
+++ b/components/org.wso2.carbon.identity.oauth2.grant.organizationswitch/src/main/java/org/wso2/carbon/identity/oauth2/grant/organizationswitch/OrganizationSwitchGrant.java
@@ -179,11 +179,7 @@ public class OrganizationSwitchGrant extends AbstractAuthorizationGrantHandler {
                                                     String appName) throws IdentityOAuth2Exception {
 
         if (StringUtils.equals(currentOrgId, switchOrgId)) {
-            if (LOG.isDebugEnabled()) {
-                LOG.debug("Provided token was already issued for the requested organization: " + switchOrgId);
-            }
-            throw new IdentityOAuth2ClientException(
-                    "Provided token was already issued for the requested organization.");
+            return;
         }
         try {
             if (getOrganizationManager()

--- a/components/org.wso2.carbon.identity.oauth2.grant.organizationswitch/src/test/java/org/wso2/carbon/identity/oauth2/grant/organizationswitch/OrganizationSwitchGrantTest.java
+++ b/components/org.wso2.carbon.identity.oauth2.grant.organizationswitch/src/test/java/org/wso2/carbon/identity/oauth2/grant/organizationswitch/OrganizationSwitchGrantTest.java
@@ -163,7 +163,7 @@ public class OrganizationSwitchGrantTest {
         organizationSwitchGrant.validateGrant(oAuthTokenReqMessageContext);
     }
 
-    @Test(expectedExceptions = IdentityOAuth2ClientException.class)
+    @Test
     public void testSwitchSameOrganization() throws IdentityOAuth2Exception, OrganizationManagementException {
 
         when(mockOAuth2TokenValidationResponseDTO.isValid()).thenReturn(true);


### PR DESCRIPTION
## Purpose

- There can be situations were B2B application allows switching to lower level organizations, and the switched token for a below level is intended to switch to directly to the main app reside organization. In such cases, the organization switch grant should not break as the switching org and app reside org are same.

- This restriction was previously added as when an access token is issued from the app resident org, there is no point in invoke switch grant request against that same org.