### PR TITLE
Fetch app id during org switch in legacy runtime

### DIFF
--- a/components/org.wso2.carbon.identity.oauth2.grant.organizationswitch/src/main/java/org/wso2/carbon/identity/oauth2/grant/organizationswitch/OrganizationSwitchGrant.java
+++ b/components/org.wso2.carbon.identity.oauth2.grant.organizationswitch/src/main/java/org/wso2/carbon/identity/oauth2/grant/organizationswitch/OrganizationSwitchGrant.java
@@ -88,7 +88,12 @@ public class OrganizationSwitchGrant extends AbstractAuthorizationGrantHandler {
         String appResideOrgId = getOrganizationIdFromTenantDomain(authorizedUser.getTenantDomain());
         OAuthAppDO oAuthAppDO = (OAuthAppDO) tokReqMsgCtx.getProperty(OAUTH_APP_PROPERTY);
         String appName = oAuthAppDO.getApplicationName();
-        String appId = getAppID(appName, authorizedUser.getTenantDomain());
+        String appId;
+        if (CarbonConstants.ENABLE_LEGACY_AUTHZ_RUNTIME && "Console".equalsIgnoreCase(appName)) {
+            appId = oAuthAppDO.getOauthConsumerKey();
+        } else {
+            appId = getAppID(appName, authorizedUser.getTenantDomain());
+        }
         checkOrganizationIsAllowedToSwitch(appResideOrgId, accessingOrgId, appId, appName);
 
         AuthenticatedUser authenticatedUser = new AuthenticatedUser(authorizedUser);


### PR DESCRIPTION
## Purpose
> Remove the shared app logic in legacy runtime for console