### PR TITLE
Add Organization Switch Client Credentials Grant

### DIFF
--- a/components/org.wso2.carbon.identity.oauth2.grant.organizationswitch/pom.xml
+++ b/components/org.wso2.carbon.identity.oauth2.grant.organizationswitch/pom.xml
@@ -61,6 +61,10 @@
             <artifactId>org.wso2.carbon.identity.application.mgt</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.wso2.carbon.identity.framework</groupId>
+            <artifactId>org.wso2.carbon.identity.testutil</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.wso2.carbon.identity.organization.management.core</groupId>
             <artifactId>org.wso2.carbon.identity.organization.management.service</artifactId>
         </dependency>

--- a/components/org.wso2.carbon.identity.oauth2.grant.organizationswitch/src/main/java/org/wso2/carbon/identity/oauth2/grant/organizationswitch/OrganizationSwitchCCGrant.java
+++ b/components/org.wso2.carbon.identity.oauth2.grant.organizationswitch/src/main/java/org/wso2/carbon/identity/oauth2/grant/organizationswitch/OrganizationSwitchCCGrant.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.oauth2.grant.organizationswitch;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.identity.oauth.common.OAuthConstants;
+import org.wso2.carbon.identity.oauth2.IdentityOAuth2Exception;
+import org.wso2.carbon.identity.oauth2.model.AccessTokenDO;
+
+public class OrganizationSwitchCCGrant extends OrganizationSwitchGrant {
+
+    private static final Log LOG = LogFactory.getLog(OrganizationSwitchCCGrant.class);
+
+    @Override
+    protected void validateGrantType(AccessTokenDO accessTokenDO) throws IdentityOAuth2Exception {
+
+        if (!OAuthConstants.GrantTypes.CLIENT_CREDENTIALS.equals(accessTokenDO.getGrantType())
+        && !OAuthConstants.GrantTypes.ORGANIZATION_SWITCH_CC.equals(accessTokenDO.getGrantType())) {
+            LOG.debug("Access token validation failed.");
+
+            throw new IdentityOAuth2Exception("Invalid grant received.");
+        }
+    }
+
+    @Override
+    public boolean isOfTypeApplicationUser() throws IdentityOAuth2Exception {
+
+        return false;
+    }
+}

--- a/components/org.wso2.carbon.identity.oauth2.grant.organizationswitch/src/main/java/org/wso2/carbon/identity/oauth2/grant/organizationswitch/OrganizationSwitchGrant.java
+++ b/components/org.wso2.carbon.identity.oauth2.grant.organizationswitch/src/main/java/org/wso2/carbon/identity/oauth2/grant/organizationswitch/OrganizationSwitchGrant.java
@@ -82,6 +82,7 @@ public class OrganizationSwitchGrant extends AbstractAuthorizationGrantHandler {
         LOG.debug("Access token validation success.");
 
         AccessTokenDO tokenDO = OAuth2Util.findAccessToken(token, false);
+        validateGrantType(tokenDO);
         AuthenticatedUser authorizedUser = nonNull(tokenDO) ? tokenDO.getAuthzUser() :
                 AuthenticatedUser.createLocalAuthenticatedUserFromSubjectIdentifier(
                         validationResponseDTO.getAuthorizedUser());
@@ -125,9 +126,6 @@ public class OrganizationSwitchGrant extends AbstractAuthorizationGrantHandler {
             tokReqMsgCtx.addProperty(TOKEN_BINDING_REFERENCE, tokenDO.getTokenBinding());
         }
 
-        if (OAuthConstants.UserType.APPLICATION.equals(tokenDO.getTokenType())) {
-            tokReqMsgCtx.addProperty(OAuthConstants.UserType.USER_TYPE, OAuthConstants.UserType.APPLICATION);
-        }
         if (LOG.isDebugEnabled()) {
             LOG.debug("Issuing an access token for user: " + authenticatedUser + " with scopes: " +
                     Arrays.toString(tokReqMsgCtx.getScope()));
@@ -254,5 +252,14 @@ public class OrganizationSwitchGrant extends AbstractAuthorizationGrantHandler {
         } catch (IdentityApplicationManagementException e) {
             throw new IdentityOAuth2Exception("Error while getting application basic info.", e);
         }
+    }
+
+    /**
+     * Validate grant type of access token.
+     *
+     * @param accessTokenDO access token to be switched
+     */
+    protected void validateGrantType(AccessTokenDO accessTokenDO) throws IdentityOAuth2Exception {
+
     }
 }

--- a/components/org.wso2.carbon.identity.oauth2.grant.organizationswitch/src/main/java/org/wso2/carbon/identity/oauth2/grant/organizationswitch/OrganizationSwitchGrant.java
+++ b/components/org.wso2.carbon.identity.oauth2.grant.organizationswitch/src/main/java/org/wso2/carbon/identity/oauth2/grant/organizationswitch/OrganizationSwitchGrant.java
@@ -261,5 +261,10 @@ public class OrganizationSwitchGrant extends AbstractAuthorizationGrantHandler {
      */
     protected void validateGrantType(AccessTokenDO accessTokenDO) throws IdentityOAuth2Exception {
 
+        if (OAuthConstants.GrantTypes.CLIENT_CREDENTIALS.equals(accessTokenDO.getGrantType())) {
+            LOG.debug("Access token validation failed.");
+
+            throw new IdentityOAuth2Exception("Invalid grant received.");
+        }
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -233,7 +233,7 @@
         <carbon.identity.framework.version>5.25.390</carbon.identity.framework.version>
         <carbon.identity.package.import.version.range>[5.20.0, 7.0.0)
         </carbon.identity.package.import.version.range>
-        <identity.inbound.auth.oauth.version>6.11.195-SNAPSHOT</identity.inbound.auth.oauth.version>
+        <identity.inbound.auth.oauth.version>6.11.196</identity.inbound.auth.oauth.version>
         <identity.inbound.auth.oauth.import.version.range>[6.7.116, 6.8.0)
         </identity.inbound.auth.oauth.import.version.range>
 

--- a/pom.xml
+++ b/pom.xml
@@ -76,6 +76,11 @@
                 <version>${carbon.identity.framework.version}</version>
             </dependency>
             <dependency>
+                <groupId>org.wso2.carbon.identity.framework</groupId>
+                <artifactId>org.wso2.carbon.identity.testutil</artifactId>
+                <version>${carbon.identity.framework.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>org.wso2.carbon.identity.organization.management.core</groupId>
                 <artifactId>org.wso2.carbon.identity.organization.management.service</artifactId>
                 <version>${carbon.identity.org.mgt.core.version}</version>
@@ -228,7 +233,7 @@
         <carbon.identity.framework.version>5.25.390</carbon.identity.framework.version>
         <carbon.identity.package.import.version.range>[5.20.0, 7.0.0)
         </carbon.identity.package.import.version.range>
-        <identity.inbound.auth.oauth.version>6.7.116</identity.inbound.auth.oauth.version>
+        <identity.inbound.auth.oauth.version>6.11.195-SNAPSHOT</identity.inbound.auth.oauth.version>
         <identity.inbound.auth.oauth.import.version.range>[6.7.116, 6.8.0)
         </identity.inbound.auth.oauth.import.version.range>
 


### PR DESCRIPTION
## Purpose
- Add Organization Switch Client Credentials Grant to
-- Switch `client_credentials` grant token issued for a parent organization to a sub organization `organization_switch_cc` token with authorized APIs of h
-- Switch `organization_switch_cc` grant token issued for a parent organization to a sub organization `organization_switch_cc` token
- Remove the fix added to get scopes for application organization switched token from CC grant token with https://github.com/wso2-extensions/identity-oauth2-grant-organization-switch/pull/25

### Related Issue
- https://github.com/wso2/product-is/issues/17532

### Depends on
- https://github.com/wso2-extensions/identity-inbound-auth-oauth/pull/2256

