### PR TITLE
[Impersonation] Improve Impersonated Access Token Exchange for Org Grant

### DIFF
--- a/components/org.wso2.carbon.identity.oauth2.grant.organizationswitch/pom.xml
+++ b/components/org.wso2.carbon.identity.oauth2.grant.organizationswitch/pom.xml
@@ -73,6 +73,10 @@
             <artifactId>org.wso2.carbon.identity.organization.management.application</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.wso2.orbit.com.nimbusds</groupId>
+            <artifactId>nimbus-jose-jwt</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
             <scope>test</scope>
@@ -131,6 +135,8 @@
                             org.wso2.carbon.user.core.tenant;version="${carbon.kernel.package.import.version.range}",
                             org.wso2.carbon.user.core.common;version="${carbon.kernel.package.import.version.range}",
                             org.wso2.carbon;version="${carbon.kernel.package.import.version.range}",
+                            com.nimbusds.jose.*; version="${nimbusds.osgi.version.range}",
+                            com.nimbusds.jwt; version="${nimbusds.osgi.version.range}"
                         </Import-Package>
                     </instructions>
                 </configuration>

--- a/components/org.wso2.carbon.identity.oauth2.grant.organizationswitch/src/main/java/org/wso2/carbon/identity/oauth2/grant/organizationswitch/OrganizationSwitchGrant.java
+++ b/components/org.wso2.carbon.identity.oauth2.grant.organizationswitch/src/main/java/org/wso2/carbon/identity/oauth2/grant/organizationswitch/OrganizationSwitchGrant.java
@@ -102,7 +102,6 @@ public class OrganizationSwitchGrant extends AbstractAuthorizationGrantHandler {
         LOG.debug("Access token validation success.");
 
         AccessTokenDO tokenDO = OAuth2Util.findAccessToken(token, false);
-        changeUserTypeForCCGrant(tokReqMsgCtx, tokenDO);
         if (isImpersonationFlow(token, tokReqMsgCtx)) {
             tokReqMsgCtx.setImpersonationRequest(true);
         }
@@ -322,19 +321,6 @@ public class OrganizationSwitchGrant extends AbstractAuthorizationGrantHandler {
             }
         } catch (IdentityApplicationManagementException e) {
             throw new IdentityOAuth2Exception("Error while getting application basic info.", e);
-        }
-    }
-
-    /**
-     * Change user type for tokens switched with client credentials grant as APPLICATION.
-     *
-     * @param tokReqMsgCtx  token request message context
-     * @param accessTokenDO access token to be switched
-     */
-    private void changeUserTypeForCCGrant(OAuthTokenReqMessageContext tokReqMsgCtx, AccessTokenDO accessTokenDO) {
-
-        if (OAuthConstants.GrantTypes.CLIENT_CREDENTIALS.equals(accessTokenDO.getGrantType())) {
-            tokReqMsgCtx.addProperty(OAuthConstants.UserType.USER_TYPE, OAuthConstants.UserType.APPLICATION);
         }
     }
 

--- a/components/org.wso2.carbon.identity.oauth2.grant.organizationswitch/src/main/java/org/wso2/carbon/identity/oauth2/grant/organizationswitch/OrganizationSwitchGrant.java
+++ b/components/org.wso2.carbon.identity.oauth2.grant.organizationswitch/src/main/java/org/wso2/carbon/identity/oauth2/grant/organizationswitch/OrganizationSwitchGrant.java
@@ -18,6 +18,8 @@
 
 package org.wso2.carbon.identity.oauth2.grant.organizationswitch;
 
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.SignedJWT;
 import org.apache.commons.lang.ArrayUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
@@ -56,8 +58,15 @@ import org.wso2.carbon.user.api.UserStoreException;
 import org.wso2.carbon.user.core.tenant.TenantManager;
 
 import java.util.Arrays;
+import java.util.Map;
 
 import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.ErrorMessages.ERROR_CODE_ERROR_RESOLVING_TENANT_DOMAIN_FROM_ORGANIZATION_DOMAIN;
+import static org.wso2.carbon.identity.oauth2.grant.organizationswitch.util.OrganizationSwitchGrantConstants.ACT;
+import static org.wso2.carbon.identity.oauth2.grant.organizationswitch.util.OrganizationSwitchGrantConstants.IMPERSONATED_SUBJECT;
+import static org.wso2.carbon.identity.oauth2.grant.organizationswitch.util.OrganizationSwitchGrantConstants.IMPERSONATING_ACTOR;
+import static org.wso2.carbon.identity.oauth2.grant.organizationswitch.util.OrganizationSwitchGrantConstants.SUB;
+import static org.wso2.carbon.identity.oauth2.grant.organizationswitch.util.OrganizationSwitchGrantUtil.getClaimSet;
+import static org.wso2.carbon.identity.oauth2.grant.organizationswitch.util.OrganizationSwitchGrantUtil.getSignedJWT;
 import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.ErrorMessages.ERROR_CODE_ORGANIZATION_NOT_FOUND_FOR_TENANT;
 
 import static java.util.Objects.nonNull;
@@ -93,6 +102,10 @@ public class OrganizationSwitchGrant extends AbstractAuthorizationGrantHandler {
         LOG.debug("Access token validation success.");
 
         AccessTokenDO tokenDO = OAuth2Util.findAccessToken(token, false);
+        changeUserTypeForCCGrant(tokReqMsgCtx, tokenDO);
+        if (isImpersonationFlow(token, tokReqMsgCtx)) {
+            tokReqMsgCtx.setImpersonationRequest(true);
+        }
         AuthenticatedUser authorizedUser = nonNull(tokenDO) ? tokenDO.getAuthzUser() :
                 AuthenticatedUser.createLocalAuthenticatedUserFromSubjectIdentifier(
                         validationResponseDTO.getAuthorizedUser());
@@ -310,5 +323,78 @@ public class OrganizationSwitchGrant extends AbstractAuthorizationGrantHandler {
         } catch (IdentityApplicationManagementException e) {
             throw new IdentityOAuth2Exception("Error while getting application basic info.", e);
         }
+    }
+
+    /**
+     * Change user type for tokens switched with client credentials grant as APPLICATION.
+     *
+     * @param tokReqMsgCtx  token request message context
+     * @param accessTokenDO access token to be switched
+     */
+    private void changeUserTypeForCCGrant(OAuthTokenReqMessageContext tokReqMsgCtx, AccessTokenDO accessTokenDO) {
+
+        if (OAuthConstants.GrantTypes.CLIENT_CREDENTIALS.equals(accessTokenDO.getGrantType())) {
+            tokReqMsgCtx.addProperty(OAuthConstants.UserType.USER_TYPE, OAuthConstants.UserType.APPLICATION);
+        }
+    }
+
+    /**
+     * Validates the subject token provided in the token exchange request.
+     * Checks if the subject token is signed by the Authorization Server (AS),
+     * validates the token claims, and ensures it's intended for the correct audience and issuer.
+     *
+     * @return true if the subject token is valid, false otherwise.
+     */
+    private boolean isImpersonationFlow(String token, OAuthTokenReqMessageContext tokReqMsgCtx)
+            throws IdentityOAuth2Exception {
+
+        // Retrieve the signed JWT object from the request parameters
+        SignedJWT signedJWT = getSignedJWT(token);
+        if (signedJWT == null) {
+            return false;
+        }
+
+        // Extract claims from the JWT
+        JWTClaimsSet claimsSet = getClaimSet(signedJWT);
+        if (claimsSet == null) {
+            return false;
+        }
+
+        // Validate mandatory claims
+        String subject = resolveSubject(claimsSet);
+        String impersonator = resolveImpersonator(claimsSet);
+        if (StringUtils.isBlank(impersonator) ||StringUtils.isBlank(subject) ) {
+            return false;
+        }
+
+        String jwtIssuer = claimsSet.getIssuer();
+        if (!validateTokenIssuer(jwtIssuer, tokReqMsgCtx.getOauth2AccessTokenReqDTO().getTenantDomain())) {
+            return false;
+        }
+
+        tokReqMsgCtx.addProperty(IMPERSONATING_ACTOR, impersonator);
+        tokReqMsgCtx.addProperty(IMPERSONATED_SUBJECT, subject);
+        return true;
+    }
+
+    private boolean validateTokenIssuer(String jwtIssuer, String tenantDomain) throws IdentityOAuth2Exception {
+
+        String expectedIssuer = OAuth2Util.getIdTokenIssuer(tenantDomain);
+        return StringUtils.equals(expectedIssuer, jwtIssuer);
+    }
+
+    private String resolveSubject(JWTClaimsSet claimsSet) {
+
+        return claimsSet.getSubject();
+    }
+
+    private String resolveImpersonator(JWTClaimsSet claimsSet) {
+
+        if (claimsSet.getClaim(ACT) != null) {
+
+            Map<String, String> mayActClaimSet = (Map) claimsSet.getClaim(ACT);
+            return mayActClaimSet.get(SUB);
+        }
+        return null;
     }
 }

--- a/components/org.wso2.carbon.identity.oauth2.grant.organizationswitch/src/main/java/org/wso2/carbon/identity/oauth2/grant/organizationswitch/util/OrganizationSwitchGrantConstants.java
+++ b/components/org.wso2.carbon.identity.oauth2.grant.organizationswitch/src/main/java/org/wso2/carbon/identity/oauth2/grant/organizationswitch/util/OrganizationSwitchGrantConstants.java
@@ -28,6 +28,10 @@ public class OrganizationSwitchGrantConstants {
     public static final String TOKEN_BINDING_REFERENCE = "tokenBindingReference";
 
     public static final String CONSOLE_APP_NAME = "Console";
+    public static final String IMPERSONATED_SUBJECT = "IMPERSONATED_SUBJECT";
+    public static final String IMPERSONATING_ACTOR = "IMPERSONATING_ACTOR";
+    public static final String ACT = "act";
+    public static final String SUB = "sub";
 
     /**
      * Constants related to request parameters.

--- a/components/org.wso2.carbon.identity.oauth2.grant.organizationswitch/src/main/java/org/wso2/carbon/identity/oauth2/grant/organizationswitch/util/OrganizationSwitchGrantUtil.java
+++ b/components/org.wso2.carbon.identity.oauth2.grant.organizationswitch/src/main/java/org/wso2/carbon/identity/oauth2/grant/organizationswitch/util/OrganizationSwitchGrantUtil.java
@@ -18,8 +18,13 @@
 
 package org.wso2.carbon.identity.oauth2.grant.organizationswitch.util;
 
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.SignedJWT;
+import org.apache.commons.lang.StringUtils;
 import org.wso2.carbon.identity.oauth2.grant.organizationswitch.exception.OrganizationSwitchGrantServerException;
 import org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants;
+
+import java.text.ParseException;
 
 /**
  * This class provides utility functions for the Organization Switch grant.
@@ -30,5 +35,45 @@ public class OrganizationSwitchGrantUtil {
             OrganizationManagementConstants.ErrorMessages error, Throwable e) {
 
         return new OrganizationSwitchGrantServerException(error.getMessage(), error.getCode(), e);
+    }
+
+    /**
+     * Get the SignedJWT by parsing the subjectToken.
+     *
+     * @param subjectToken Token sent in the request
+     * @return SignedJWT
+     */
+    public static SignedJWT getSignedJWT(String subjectToken)  {
+
+        SignedJWT signedJWT;
+        if (StringUtils.isEmpty(subjectToken)) {
+            return null;
+        }
+        try {
+            signedJWT = SignedJWT.parse(subjectToken);
+        } catch (ParseException e) {
+            return null;
+        }
+        return signedJWT;
+    }
+
+    /**
+     * Retrieve the JWTClaimsSet from the SignedJWT.
+     *
+     * @param signedJWT SignedJWT object
+     * @return JWTClaimsSet
+     */
+    public static JWTClaimsSet getClaimSet(SignedJWT signedJWT) {
+
+        JWTClaimsSet claimsSet;
+        try {
+            claimsSet = signedJWT.getJWTClaimsSet();
+            if (claimsSet == null) {
+                return null;
+            }
+        } catch (ParseException e) {
+            return null;
+        }
+        return claimsSet;
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -96,6 +96,11 @@
                 <version>${oltu.oauth2.client.version}</version>
             </dependency>
             <dependency>
+                <groupId>org.wso2.orbit.com.nimbusds</groupId>
+                <artifactId>nimbus-jose-jwt</artifactId>
+                <version>${nimbusds.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>org.wso2.carbon.extension.identity.oauth2.grantType.organizationswitch</groupId>
                 <artifactId>org.wso2.carbon.identity.oauth2.grant.organizationswitch</artifactId>
                 <version>${project.version}</version>
@@ -236,6 +241,9 @@
         <identity.inbound.auth.oauth.version>7.0.78</identity.inbound.auth.oauth.version>
         <identity.inbound.auth.oauth.import.version.range>[6.7.116, 8.0.0)
         </identity.inbound.auth.oauth.import.version.range>
+
+        <nimbusds.osgi.version.range>[7.3.0,8.0.0)</nimbusds.osgi.version.range>
+        <nimbusds.version>7.3.0.wso2v1</nimbusds.version>
 
         <org.apache.commons.lang.imp.pkg.version.range>[2.6,3)</org.apache.commons.lang.imp.pkg.version.range>
         <org.apache.commons.logging.imp.pkg.version.range>[1.2,2)</org.apache.commons.logging.imp.pkg.version.range>

--- a/pom.xml
+++ b/pom.xml
@@ -238,7 +238,7 @@
         <carbon.identity.framework.version>5.25.390</carbon.identity.framework.version>
         <carbon.identity.package.import.version.range>[5.20.0, 8.0.0)
         </carbon.identity.package.import.version.range>
-        <identity.inbound.auth.oauth.version>7.0.78</identity.inbound.auth.oauth.version>
+        <identity.inbound.auth.oauth.version>7.0.97</identity.inbound.auth.oauth.version>
         <identity.inbound.auth.oauth.import.version.range>[6.7.116, 8.0.0)
         </identity.inbound.auth.oauth.import.version.range>
 


### PR DESCRIPTION
Public Issue: https://github.com/wso2/product-is/issues/20066

## Purpose
When the impersonator acquired impersonated AT for root org, he/she can exchange the token for AT to access sub org resources. This fix will deliver above exchange capability.

## Approach
From the request we validate whether the request param contain a impersonated access token or not. If its an impersonated access token we validate the mandatory claims and set for property in the tokenContext.


```
IMPERSONATING_REQUEST -> true
IMPERSONATING_ACTOR -> impersonator
IMPERSONATED_SUBJECT -> subject
```
Token Issuer will handle the rest.


## Sample Request

```
curl -X POST \
  https://localhost:9443/oauth2/token \
  -H 'Authorization: Basic  <xxx:xxx>' \
  -d 'client_id=<CLIENT_DI>' \
  -d 'grant_type=organization_switch' \
  -d 'scope=<SCOPE>' \
  -d 'switching_organization=<ORG_ID>' \
  -d 'token=<IMPERSONATED_AT>'
```

## Sample Impersonated JWT AT Payload

```
{
  "sub": "8122e3de-0f3b-4b0e-a43a-d0c237451b7a",
  "aut": "APPLICATION_USER",
  "iss": "https://localhost:9443/oauth2/token",
  "client_id": "89QgcFmZaWVf0hNiE_u4y7AkWa4a",
  "aud": "89QgcFmZaWVf0hNiE_u4y7AkWa4a",
  "user_org": "10084a8d-113f-4211-a0d5-efe36b082211",
  "nbf": 1713762291,
  "act": {
    "sub": "d9982d93-4e73-4565-b7ac-3605e8d05f80"
  },
  "azp": "89QgcFmZaWVf0hNiE_u4y7AkWa4a",
  "org_id": "3890dce6-81f0-49f6-853f-0b0a7aad05d6",
  "scope": "SYSTEM internal_user_mgt_delete internal_user_mgt_list openid profile",
  "exp": 1713765891,
  "org_name": "SubOrg",
  "iat": 1713762291,
  "jti": "7cb39081-5eac-497e-a243-8e0ae891e16c"
}
```

## Demo

https://github.com/wso2-extensions/identity-oauth2-grant-organization-switch/assets/25488962/fb6e3187-701e-43d1-b08d-addf03602899

Merge Condition
- [x] OAuth PR merged
- [x] OAuth version bumped
- [x] Unit test covered.




