### PR TITLE
Publish post events for org switch

### DIFF
--- a/components/org.wso2.carbon.identity.oauth2.grant.organizationswitch/pom.xml
+++ b/components/org.wso2.carbon.identity.oauth2.grant.organizationswitch/pom.xml
@@ -197,7 +197,8 @@
                             org.wso2.carbon.user.core.common;version="${carbon.kernel.package.import.version.range}",
                             org.wso2.carbon;version="${carbon.kernel.package.import.version.range}",
                             com.nimbusds.jose.*; version="${nimbusds.osgi.version.range}",
-                            com.nimbusds.jwt; version="${nimbusds.osgi.version.range}"
+                            com.nimbusds.jwt; version="${nimbusds.osgi.version.range}",
+                            org.wso2.carbon.identity.event.*; version="${carbon.identity.package.import.version.range}"
                         </Import-Package>
                     </instructions>
                 </configuration>

--- a/components/org.wso2.carbon.identity.oauth2.grant.organizationswitch/pom.xml
+++ b/components/org.wso2.carbon.identity.oauth2.grant.organizationswitch/pom.xml
@@ -202,7 +202,8 @@
                             org.wso2.carbon;version="${carbon.kernel.package.import.version.range}",
                             com.nimbusds.jose.*; version="${nimbusds.osgi.version.range}",
                             com.nimbusds.jwt; version="${nimbusds.osgi.version.range}",
-                            org.wso2.carbon.identity.event.*; version="${carbon.identity.package.import.version.range}"
+                            org.wso2.carbon.identity.event.*; version="${carbon.identity.package.import.version.range}",
+                            org.wso2.carbon.context; version="${carbon.kernel.package.import.version.range}",
                         </Import-Package>
                     </instructions>
                 </configuration>

--- a/components/org.wso2.carbon.identity.oauth2.grant.organizationswitch/pom.xml
+++ b/components/org.wso2.carbon.identity.oauth2.grant.organizationswitch/pom.xml
@@ -66,6 +66,10 @@
         </dependency>
         <dependency>
             <groupId>org.wso2.carbon.identity.framework</groupId>
+            <artifactId>org.wso2.carbon.identity.event</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.framework</groupId>
             <artifactId>org.wso2.carbon.identity.testutil</artifactId>
         </dependency>
         <dependency>

--- a/components/org.wso2.carbon.identity.oauth2.grant.organizationswitch/src/main/java/org/wso2/carbon/identity/oauth2/grant/organizationswitch/OrganizationSwitchGrant.java
+++ b/components/org.wso2.carbon.identity.oauth2.grant.organizationswitch/src/main/java/org/wso2/carbon/identity/oauth2/grant/organizationswitch/OrganizationSwitchGrant.java
@@ -30,6 +30,8 @@ import org.wso2.carbon.identity.application.common.IdentityApplicationManagement
 import org.wso2.carbon.identity.application.common.model.ApplicationBasicInfo;
 import org.wso2.carbon.identity.application.mgt.ApplicationManagementService;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
+import org.wso2.carbon.identity.event.IdentityEventException;
+import org.wso2.carbon.identity.event.event.Event;
 import org.wso2.carbon.identity.oauth.common.OAuth2ErrorCodes;
 import org.wso2.carbon.identity.oauth.common.OAuthConstants;
 import org.wso2.carbon.identity.oauth.config.OAuthServerConfiguration;
@@ -59,8 +61,10 @@ import org.wso2.carbon.user.api.UserStoreException;
 import org.wso2.carbon.user.core.tenant.TenantManager;
 
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.Map;
 
+import static org.wso2.carbon.identity.event.IdentityEventConstants.EventProperty.ERROR_CODE;
 import static org.wso2.carbon.identity.oauth.common.OAuthConstants.GrantTypes.ORGANIZATION_SWITCH;
 import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.ErrorMessages.ERROR_CODE_ERROR_RESOLVING_TENANT_DOMAIN_FROM_ORGANIZATION_DOMAIN;
 import static org.wso2.carbon.identity.oauth2.grant.organizationswitch.util.OrganizationSwitchGrantConstants.ACT;
@@ -81,6 +85,8 @@ public class OrganizationSwitchGrant extends AbstractAuthorizationGrantHandler {
     private static final Log LOG = LogFactory.getLog(OrganizationSwitchGrant.class);
     private static final String TOKEN_BINDING_REFERENCE = "tokenBindingReference";
     private static final String OAUTH_APP_PROPERTY = "OAuthAppDO";
+    public static final String OAUTH_TOKEN_REQ_MESSAGE_CONTEXT = "OAUTH_TOKEN_REQ_MESSAGE_CONTEXT";
+    public static final String POST_ORGANIZATION_SWITCH_EVENT = "POST_ORGANIZATION_SWITCH_EVENT";
 
     @Override
     public boolean validateGrant(OAuthTokenReqMessageContext tokReqMsgCtx) throws IdentityOAuth2Exception {
@@ -234,7 +240,23 @@ public class OrganizationSwitchGrant extends AbstractAuthorizationGrantHandler {
         if (tokReqMsgCtx.getProperty(TOKEN_BINDING_REFERENCE) != null) {
             tokReqMsgCtx.setTokenBinding((TokenBinding) tokReqMsgCtx.getProperty(TOKEN_BINDING_REFERENCE));
         }
-        return super.issue(tokReqMsgCtx);
+        OAuth2AccessTokenRespDTO oAuth2AccessTokenRespDTO = super.issue(tokReqMsgCtx);
+        publishOrgSwitchEvent(tokReqMsgCtx, oAuth2AccessTokenRespDTO.getErrorCode());
+        return oAuth2AccessTokenRespDTO;
+    }
+
+    public static void publishOrgSwitchEvent(OAuthTokenReqMessageContext context, String errorCode) {
+
+        HashMap<String, Object> properties = new HashMap<>();
+        properties.put(OAUTH_TOKEN_REQ_MESSAGE_CONTEXT, context);
+        properties.put(ERROR_CODE, errorCode);
+
+        Event event = new Event(POST_ORGANIZATION_SWITCH_EVENT, properties);
+        try {
+            OrganizationSwitchGrantDataHolder.getInstance().getIdentityEventService().handleEvent(event);
+        } catch (IdentityEventException e) {
+            LOG.error("Error while publishing events for organization switch", e);
+        }
     }
 
     private String extractParameter(String param, OAuthTokenReqMessageContext tokReqMsgCtx) {

--- a/components/org.wso2.carbon.identity.oauth2.grant.organizationswitch/src/main/java/org/wso2/carbon/identity/oauth2/grant/organizationswitch/OrganizationSwitchGrant.java
+++ b/components/org.wso2.carbon.identity.oauth2.grant.organizationswitch/src/main/java/org/wso2/carbon/identity/oauth2/grant/organizationswitch/OrganizationSwitchGrant.java
@@ -25,6 +25,7 @@ import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.CarbonConstants;
+import org.wso2.carbon.context.PrivilegedCarbonContext;
 import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticatedUser;
 import org.wso2.carbon.identity.application.common.IdentityApplicationManagementException;
 import org.wso2.carbon.identity.application.common.model.ApplicationBasicInfo;
@@ -68,11 +69,8 @@ import static org.wso2.carbon.identity.oauth.common.OAuthConstants.GrantTypes.OR
 
 import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.ErrorMessages.ERROR_CODE_ERROR_RESOLVING_TENANT_DOMAIN_FROM_ORGANIZATION_DOMAIN;
 import static org.wso2.carbon.identity.oauth2.grant.organizationswitch.util.OrganizationSwitchGrantConstants.ACT;
-import static org.wso2.carbon.identity.oauth2.grant.organizationswitch.util.OrganizationSwitchGrantConstants.ERROR_CODE;
 import static org.wso2.carbon.identity.oauth2.grant.organizationswitch.util.OrganizationSwitchGrantConstants.IMPERSONATED_SUBJECT;
 import static org.wso2.carbon.identity.oauth2.grant.organizationswitch.util.OrganizationSwitchGrantConstants.IMPERSONATING_ACTOR;
-import static org.wso2.carbon.identity.oauth2.grant.organizationswitch.util.OrganizationSwitchGrantConstants.OAUTH_TOKEN_REQ_MESSAGE_CONTEXT;
-import static org.wso2.carbon.identity.oauth2.grant.organizationswitch.util.OrganizationSwitchGrantConstants.POST_ORGANIZATION_SWITCH_EVENT;
 import static org.wso2.carbon.identity.oauth2.grant.organizationswitch.util.OrganizationSwitchGrantConstants.SUB;
 import static org.wso2.carbon.identity.oauth2.grant.organizationswitch.util.OrganizationSwitchGrantUtil.getClaimSet;
 import static org.wso2.carbon.identity.oauth2.grant.organizationswitch.util.OrganizationSwitchGrantUtil.getSignedJWT;
@@ -88,6 +86,12 @@ public class OrganizationSwitchGrant extends AbstractAuthorizationGrantHandler {
     private static final Log LOG = LogFactory.getLog(OrganizationSwitchGrant.class);
     private static final String TOKEN_BINDING_REFERENCE = "tokenBindingReference";
     private static final String OAUTH_APP_PROPERTY = "OAuthAppDO";
+    private static final String EVENT_PROP_AUTHENTICATED_USER = "AUTHENTICATED_USER";
+    private static final String EVENT_PROP_APPLICATION_NAME = "APPLICATION_NAME";
+    private static final String EVENT_PROP_APPLICATION_TENANT_DOMAIN = "APPLICATION_TENANT_DOMAIN";
+    private static final String EVENT_PROP_TENANT_DOMAIN = "TENANT_DOMAIN";
+    private static final String POST_ORGANIZATION_SWITCH_EVENT = "POST_ORGANIZATION_SWITCH_EVENT";
+    private static final String ERROR_CODE = "ERROR_CODE";
 
     @Override
     public boolean validateGrant(OAuthTokenReqMessageContext tokReqMsgCtx) throws IdentityOAuth2Exception {
@@ -248,16 +252,30 @@ public class OrganizationSwitchGrant extends AbstractAuthorizationGrantHandler {
 
     public static void publishOrgSwitchEvent(OAuthTokenReqMessageContext context, String errorCode) {
 
-        HashMap<String, Object> properties = new HashMap<>();
-        properties.put(OAUTH_TOKEN_REQ_MESSAGE_CONTEXT, context);
-        properties.put(ERROR_CODE, errorCode);
-
-        Event event = new Event(POST_ORGANIZATION_SWITCH_EVENT, properties);
+        Event event = buildEvent(context, errorCode);
         try {
             OrganizationSwitchGrantDataHolder.getInstance().getIdentityEventService().handleEvent(event);
         } catch (IdentityEventException e) {
             LOG.error("Error while publishing events for organization switch", e);
         }
+    }
+
+    private static Event buildEvent(OAuthTokenReqMessageContext context, String errorCode) {
+
+        HashMap<String, Object> properties = new HashMap<>();
+        properties.put(EVENT_PROP_AUTHENTICATED_USER, context.getAuthorizedUser());
+        OAuthAppDO oAuthAppDO = (OAuthAppDO) context.getProperty(OAUTH_APP_PROPERTY);
+        if (oAuthAppDO != null) {
+            String appTenantDomain = OAuth2Util.getTenantDomainOfOauthApp(
+                    (OAuthAppDO) context.getProperty(OAUTH_APP_PROPERTY));
+            properties.put(EVENT_PROP_APPLICATION_TENANT_DOMAIN, appTenantDomain);
+            properties.put(EVENT_PROP_APPLICATION_NAME, oAuthAppDO.getApplicationName());
+
+        }
+        properties.put(EVENT_PROP_TENANT_DOMAIN,
+                PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantDomain());
+        properties.put(ERROR_CODE, errorCode);
+        return new Event(POST_ORGANIZATION_SWITCH_EVENT, properties);
     }
 
     private String extractParameter(String param, OAuthTokenReqMessageContext tokReqMsgCtx) {

--- a/components/org.wso2.carbon.identity.oauth2.grant.organizationswitch/src/main/java/org/wso2/carbon/identity/oauth2/grant/organizationswitch/OrganizationSwitchGrant.java
+++ b/components/org.wso2.carbon.identity.oauth2.grant.organizationswitch/src/main/java/org/wso2/carbon/identity/oauth2/grant/organizationswitch/OrganizationSwitchGrant.java
@@ -64,11 +64,11 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.wso2.carbon.identity.event.IdentityEventConstants.EventProperty.ERROR_CODE;
 import static org.wso2.carbon.identity.oauth.common.OAuthConstants.GrantTypes.ORGANIZATION_SWITCH;
 
 import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.ErrorMessages.ERROR_CODE_ERROR_RESOLVING_TENANT_DOMAIN_FROM_ORGANIZATION_DOMAIN;
 import static org.wso2.carbon.identity.oauth2.grant.organizationswitch.util.OrganizationSwitchGrantConstants.ACT;
+import static org.wso2.carbon.identity.oauth2.grant.organizationswitch.util.OrganizationSwitchGrantConstants.ERROR_CODE;
 import static org.wso2.carbon.identity.oauth2.grant.organizationswitch.util.OrganizationSwitchGrantConstants.IMPERSONATED_SUBJECT;
 import static org.wso2.carbon.identity.oauth2.grant.organizationswitch.util.OrganizationSwitchGrantConstants.IMPERSONATING_ACTOR;
 import static org.wso2.carbon.identity.oauth2.grant.organizationswitch.util.OrganizationSwitchGrantConstants.OAUTH_TOKEN_REQ_MESSAGE_CONTEXT;

--- a/components/org.wso2.carbon.identity.oauth2.grant.organizationswitch/src/main/java/org/wso2/carbon/identity/oauth2/grant/organizationswitch/OrganizationSwitchGrant.java
+++ b/components/org.wso2.carbon.identity.oauth2.grant.organizationswitch/src/main/java/org/wso2/carbon/identity/oauth2/grant/organizationswitch/OrganizationSwitchGrant.java
@@ -66,10 +66,13 @@ import java.util.Map;
 
 import static org.wso2.carbon.identity.event.IdentityEventConstants.EventProperty.ERROR_CODE;
 import static org.wso2.carbon.identity.oauth.common.OAuthConstants.GrantTypes.ORGANIZATION_SWITCH;
+
 import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.ErrorMessages.ERROR_CODE_ERROR_RESOLVING_TENANT_DOMAIN_FROM_ORGANIZATION_DOMAIN;
 import static org.wso2.carbon.identity.oauth2.grant.organizationswitch.util.OrganizationSwitchGrantConstants.ACT;
 import static org.wso2.carbon.identity.oauth2.grant.organizationswitch.util.OrganizationSwitchGrantConstants.IMPERSONATED_SUBJECT;
 import static org.wso2.carbon.identity.oauth2.grant.organizationswitch.util.OrganizationSwitchGrantConstants.IMPERSONATING_ACTOR;
+import static org.wso2.carbon.identity.oauth2.grant.organizationswitch.util.OrganizationSwitchGrantConstants.OAUTH_TOKEN_REQ_MESSAGE_CONTEXT;
+import static org.wso2.carbon.identity.oauth2.grant.organizationswitch.util.OrganizationSwitchGrantConstants.POST_ORGANIZATION_SWITCH_EVENT;
 import static org.wso2.carbon.identity.oauth2.grant.organizationswitch.util.OrganizationSwitchGrantConstants.SUB;
 import static org.wso2.carbon.identity.oauth2.grant.organizationswitch.util.OrganizationSwitchGrantUtil.getClaimSet;
 import static org.wso2.carbon.identity.oauth2.grant.organizationswitch.util.OrganizationSwitchGrantUtil.getSignedJWT;
@@ -85,8 +88,6 @@ public class OrganizationSwitchGrant extends AbstractAuthorizationGrantHandler {
     private static final Log LOG = LogFactory.getLog(OrganizationSwitchGrant.class);
     private static final String TOKEN_BINDING_REFERENCE = "tokenBindingReference";
     private static final String OAUTH_APP_PROPERTY = "OAuthAppDO";
-    public static final String OAUTH_TOKEN_REQ_MESSAGE_CONTEXT = "OAUTH_TOKEN_REQ_MESSAGE_CONTEXT";
-    public static final String POST_ORGANIZATION_SWITCH_EVENT = "POST_ORGANIZATION_SWITCH_EVENT";
 
     @Override
     public boolean validateGrant(OAuthTokenReqMessageContext tokReqMsgCtx) throws IdentityOAuth2Exception {

--- a/components/org.wso2.carbon.identity.oauth2.grant.organizationswitch/src/main/java/org/wso2/carbon/identity/oauth2/grant/organizationswitch/internal/OrganizationSwitchGrantDataHolder.java
+++ b/components/org.wso2.carbon.identity.oauth2.grant.organizationswitch/src/main/java/org/wso2/carbon/identity/oauth2/grant/organizationswitch/internal/OrganizationSwitchGrantDataHolder.java
@@ -19,6 +19,7 @@
 package org.wso2.carbon.identity.oauth2.grant.organizationswitch.internal;
 
 import org.wso2.carbon.identity.application.mgt.ApplicationManagementService;
+import org.wso2.carbon.identity.event.services.IdentityEventService;
 import org.wso2.carbon.identity.oauth2.OAuth2TokenValidationService;
 import org.wso2.carbon.identity.organization.management.application.OrgApplicationManager;
 import org.wso2.carbon.identity.organization.management.service.OrganizationManager;
@@ -38,6 +39,7 @@ public class OrganizationSwitchGrantDataHolder {
     private OrgApplicationManager orgApplicationManager;
     private ApplicationManagementService applicationManagementService;
     private RealmService realmService;
+    private IdentityEventService identityEventService;
 
     public static OrganizationSwitchGrantDataHolder getInstance() {
 
@@ -153,5 +155,15 @@ public class OrganizationSwitchGrantDataHolder {
     public void setRealmService(RealmService realmService) {
 
         this.realmService = realmService;
+    }
+
+    public IdentityEventService getIdentityEventService() {
+
+        return identityEventService;
+    }
+
+    public void setIdentityEventService(IdentityEventService identityEventService) {
+
+        this.identityEventService = identityEventService;
     }
 }

--- a/components/org.wso2.carbon.identity.oauth2.grant.organizationswitch/src/main/java/org/wso2/carbon/identity/oauth2/grant/organizationswitch/internal/OrganizationSwitchGrantServiceComponent.java
+++ b/components/org.wso2.carbon.identity.oauth2.grant.organizationswitch/src/main/java/org/wso2/carbon/identity/oauth2/grant/organizationswitch/internal/OrganizationSwitchGrantServiceComponent.java
@@ -25,6 +25,7 @@ import org.osgi.service.component.annotations.Reference;
 import org.osgi.service.component.annotations.ReferenceCardinality;
 import org.osgi.service.component.annotations.ReferencePolicy;
 import org.wso2.carbon.identity.application.mgt.ApplicationManagementService;
+import org.wso2.carbon.identity.event.services.IdentityEventService;
 import org.wso2.carbon.identity.oauth2.OAuth2TokenValidationService;
 import org.wso2.carbon.identity.organization.management.application.OrgApplicationManager;
 import org.wso2.carbon.identity.organization.management.application.internal.OrgApplicationMgtDataHolder;
@@ -182,5 +183,22 @@ public class OrganizationSwitchGrantServiceComponent {
 
         OrganizationSwitchGrantDataHolder.getInstance().setRealmService(null);
         LOG.debug("Realm service unset in OrganizationSwitchGrantDataHolder.");
+    }
+
+    @Reference(
+            name = "identity.event.service",
+            service = IdentityEventService.class,
+            cardinality = ReferenceCardinality.MULTIPLE,
+            policy = ReferencePolicy.DYNAMIC,
+            unbind = "unsetIdentityEventService"
+    )
+    protected void setIdentityEventService(IdentityEventService identityEventService) {
+
+        OrganizationSwitchGrantDataHolder.getInstance().setIdentityEventService(identityEventService);
+    }
+
+    protected void unsetIdentityEventService(IdentityEventService identityEventService) {
+
+        OrganizationSwitchGrantDataHolder.getInstance().setIdentityEventService(null);
     }
 }

--- a/components/org.wso2.carbon.identity.oauth2.grant.organizationswitch/src/main/java/org/wso2/carbon/identity/oauth2/grant/organizationswitch/internal/OrganizationSwitchGrantServiceComponent.java
+++ b/components/org.wso2.carbon.identity.oauth2.grant.organizationswitch/src/main/java/org/wso2/carbon/identity/oauth2/grant/organizationswitch/internal/OrganizationSwitchGrantServiceComponent.java
@@ -188,7 +188,7 @@ public class OrganizationSwitchGrantServiceComponent {
     @Reference(
             name = "identity.event.service",
             service = IdentityEventService.class,
-            cardinality = ReferenceCardinality.MULTIPLE,
+            cardinality = ReferenceCardinality.MANDATORY,
             policy = ReferencePolicy.DYNAMIC,
             unbind = "unsetIdentityEventService"
     )

--- a/components/org.wso2.carbon.identity.oauth2.grant.organizationswitch/src/main/java/org/wso2/carbon/identity/oauth2/grant/organizationswitch/util/OrganizationSwitchGrantConstants.java
+++ b/components/org.wso2.carbon.identity.oauth2.grant.organizationswitch/src/main/java/org/wso2/carbon/identity/oauth2/grant/organizationswitch/util/OrganizationSwitchGrantConstants.java
@@ -34,6 +34,7 @@ public class OrganizationSwitchGrantConstants {
     public static final String SUB = "sub";
     public static final String OAUTH_TOKEN_REQ_MESSAGE_CONTEXT = "OAUTH_TOKEN_REQ_MESSAGE_CONTEXT";
     public static final String POST_ORGANIZATION_SWITCH_EVENT = "POST_ORGANIZATION_SWITCH_EVENT";
+    public static final String ERROR_CODE = "ERROR_CODE";
 
     /**
      * Constants related to request parameters.

--- a/components/org.wso2.carbon.identity.oauth2.grant.organizationswitch/src/main/java/org/wso2/carbon/identity/oauth2/grant/organizationswitch/util/OrganizationSwitchGrantConstants.java
+++ b/components/org.wso2.carbon.identity.oauth2.grant.organizationswitch/src/main/java/org/wso2/carbon/identity/oauth2/grant/organizationswitch/util/OrganizationSwitchGrantConstants.java
@@ -32,9 +32,6 @@ public class OrganizationSwitchGrantConstants {
     public static final String IMPERSONATING_ACTOR = "IMPERSONATING_ACTOR";
     public static final String ACT = "act";
     public static final String SUB = "sub";
-    public static final String OAUTH_TOKEN_REQ_MESSAGE_CONTEXT = "OAUTH_TOKEN_REQ_MESSAGE_CONTEXT";
-    public static final String POST_ORGANIZATION_SWITCH_EVENT = "POST_ORGANIZATION_SWITCH_EVENT";
-    public static final String ERROR_CODE = "ERROR_CODE";
 
     /**
      * Constants related to request parameters.

--- a/components/org.wso2.carbon.identity.oauth2.grant.organizationswitch/src/main/java/org/wso2/carbon/identity/oauth2/grant/organizationswitch/util/OrganizationSwitchGrantConstants.java
+++ b/components/org.wso2.carbon.identity.oauth2.grant.organizationswitch/src/main/java/org/wso2/carbon/identity/oauth2/grant/organizationswitch/util/OrganizationSwitchGrantConstants.java
@@ -32,6 +32,8 @@ public class OrganizationSwitchGrantConstants {
     public static final String IMPERSONATING_ACTOR = "IMPERSONATING_ACTOR";
     public static final String ACT = "act";
     public static final String SUB = "sub";
+    public static final String OAUTH_TOKEN_REQ_MESSAGE_CONTEXT = "OAUTH_TOKEN_REQ_MESSAGE_CONTEXT";
+    public static final String POST_ORGANIZATION_SWITCH_EVENT = "POST_ORGANIZATION_SWITCH_EVENT";
 
     /**
      * Constants related to request parameters.

--- a/pom.xml
+++ b/pom.xml
@@ -82,6 +82,11 @@
             </dependency>
             <dependency>
                 <groupId>org.wso2.carbon.identity.framework</groupId>
+                <artifactId>org.wso2.carbon.identity.event</artifactId>
+                <version>${carbon.identity.framework.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.wso2.carbon.identity.framework</groupId>
                 <artifactId>org.wso2.carbon.identity.testutil</artifactId>
                 <version>${carbon.identity.framework.version}</version>
             </dependency>


### PR DESCRIPTION
## Purpose
> Publish events after issuing a token from organization switch grant type

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Organization switch operations in OAuth2 flows now generate trackable events, enabling enhanced auditing and monitoring of organization switching activities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->